### PR TITLE
State Latch Fix for the Static Fire Feb 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Works with the launch box to send valve control signals with protected logic
 ## Ground station finite state machine
 * One of the following mode will be ran during each void loop() call
 * Dev Mode: all valves can be individually controlled
-* Fuel Mode: only the vent valves (LGN-V, LOX-V, GN2-V) can be opened; all flow and pressure valves are forced to close (LGN-F, LOX-f, LNG-P, LOX-P all closed)
+* Fuel Mode: only the vent valves (LGN-V, LOX-V, GN2-V) can be opened; all flow and pressure valves are forced to close (LNG-F, LOX-f, LNG-P, LOX-P all closed)
 * Launch Mode: ARM and then launch; Emergency Stop can be triggered anytime to open all vent valevs to release pressure
 
 ## Binary encoding of the buttons/switches

--- a/README.md
+++ b/README.md
@@ -2,8 +2,18 @@
 Phoenix ground station with Arduino \
 Works with the launch box to send valve control signals with protected logic
 
+## Latest fix after static fire on Febrary 15, 2026
+* A switch latch bug was discovered during the static fire
+* Trigger condition: Launch Mode -> ARM Switch ON-> Launch Button -> DEV Mode -> ARM Swtich OFF -> Launch Button
+* When performing a launch (usually cold flow before static fire), and close the ARM switch outside of the launch mode, there will be a very brief moment that the ground station will sent ARM ON state to the flight computer when entering the launch mode again. This is due to the debounce switch reading mechanism.
+* This branch has been archieved in ``static-fire-Feb2026-record``
+* The current main branch has patched this fix to enforce a 2 second sensor read stabalization time when swtiching state, as well as a state check when entering the launch mode. Any invalid state will prevent entering the launch mode and revert back to the previous state.
+
 ## Ground station finite state machine
 * One of the following mode will be ran during each void loop() call
+* Dev Mode: all valves can be individually controlled
+* Fuel Mode: only the vent valves (LGN-V, LOX-V, GN2-V) can be opened; all flow and pressure valves are forced to close (LGN-F, LOX-f, LNG-P, LOX-P all closed)
+* Launch Mode: ARM and then launch; Emergency Stop can be triggered anytime to open all vent valevs to release pressure
 
 ## Binary encoding of the buttons/switches
 
@@ -26,7 +36,7 @@ null_mask = 0b0000000;
 
 
 ## Launch Mode (Risk: Low)
-Launch sequence has four stages \
+Launch sequence has four stages
 
 ### PRE-ARM (0000000)
 * default state, nothing happens
@@ -80,15 +90,13 @@ Launch sequence has four stages \
 ![My Image](./lib/diagrams/pheonix-fc-launch-control-dev.svg)
 
 
-## Fuel and valve diagram
-<img src="./lib/diagrams/fuel-diagram.jpg" alt="drawing" width="400"/>
 
 ## Draw.io Link
 * https://drive.google.com/file/d/1tbEu6RL3mTaqcmE_wz8DDxYVTB-fJ5dZ/view?usp=sharing
 
 # Launch Terminal Physical Specifications
 ## Ethernet
-[W5500 Ethernet LAN Network Module](https://www.amazon.com/HiLetgo-Ethernet-Network-Support-Microcontroller/dp/B0CDWX9VQ5)
+* [W5500 Ethernet LAN Network Module](https://www.amazon.com/HiLetgo-Ethernet-Network-Support-Microcontroller/dp/B0CDWX9VQ5)
 
 
 # Resource

--- a/gs/constants.h
+++ b/gs/constants.h
@@ -60,4 +60,10 @@ const uint8_t MAC_FLOW_VALVE[6] = {0x02, 0x46, 0x4C,
 const uint8_t MAC_SENSOR_GIGA[6] = {0x02, 0x53, 0x49,
                                     0x00, 0x00, 0x04}; // SI:  sensor interface
 
+// ─────────────────────────────────────────────────────────────────────────────
+//                           Sensor Count Setup
+// ─────────────────────────────────────────────────────────────────────────────
+const size_t NUM_PTS = 7;
+const size_t NUM_LCS = 3;
+const size_t NUM_TCS = 5;
 #endif

--- a/gs/gs.ino
+++ b/gs/gs.ino
@@ -416,15 +416,14 @@ void reset_readings()
 
 /**
  * @brief  Give out launch mode fail message depending on the event
- *
+ * event_id 0: one or more of the valve switches are open
+ * event_id 1: one or more of the: ARM, ABORT, or LAUNCH are ON
  * @return void
  */
 void launch_mode_fail_message(uint8_t event_id)
 {
 
   switch (event_id){
-
-
     case (0):
       lcd.clear(); // wipe previous frame
       lcd.setCursor(0, 0);

--- a/gs/gs.ino
+++ b/gs/gs.ino
@@ -60,6 +60,7 @@ enum MODE
 
 MODE pre_operationMode = NONE_MODE;
 MODE operationMode = NONE_MODE;
+bool launchEntryLocked = false;
 
 // ─────────────────────────────────────────────────────────────────────────────
 //                           Ethernet (MAC‑RAW) Setup
@@ -221,6 +222,17 @@ MODE getModePress(MODE PRE_MODE)
   debounceButtonRead(&dev_M);
 
   unsigned int launch_button = launch_M.currState;
+
+  // Special logic to prevent invalid entry to launch mode
+  if (!launch_button)
+  {
+    launchEntryLocked = false;
+  }
+  if (launch_button && launchEntryLocked)
+  {
+    return PRE_MODE;
+  }
+
   unsigned int fueling_button = fueling_M.currState;
   unsigned int dev_button = dev_M.currState;
 
@@ -885,8 +897,20 @@ void loop()
         // If the safety check fails, force go back to the previous mode
         if (!launch_mode_check())
         {
+          launchEntryLocked = true;
           operationMode = pre_operationMode;
-          break;
+          delay(2000);
+
+          if (operationMode == FUELING_MODE)
+          {
+            LCD_DevAndFueling(1);
+          }
+
+          if (operationMode == DEV_MODE)
+          {
+            LCD_DevAndFueling(0);
+            break;
+          }
         }
 
         LCD_LaunchMode(); 

--- a/gs/gs.ino
+++ b/gs/gs.ino
@@ -360,6 +360,100 @@ void LCD_LaunchMode()
 }
 
 // ============================================================================
+//                            Mode-Setup Logic
+// ============================================================================
+/**
+ * @brief  Reset switches and buttons readings when switching state
+ *
+ * Force the ground station to read all switches/buttons for states for 2s
+ * before entering that state. This allow the debounce time to relax and
+ * ensure all switches/buttons are at the state intended.
+ *
+ * @return void
+ */
+void reset_readings()
+{
+  unsigned long timer;
+
+  lcd.clear(); // wipe previous frame
+  lcd.setCursor(0, 0);
+  lcd.print("  SWITCHING STATE  ");
+  lcd.setCursor(0, 1);
+  lcd.print("      WAIT...      ");
+
+  // Force the ground station to update the switch readings for 2 seconds
+  timer = millis();
+  while (millis() - timer < 2000){
+    // Read all swiches and buttons
+    debounceSwitchRead(&arm);
+    debounceAbortRead(&abort_mission);
+    debounceButtonRead(&launch);
+
+    DebouncedInput *valve_list[] = {&lngPressure,
+                                    &loxPressure,
+                                    &lngFlow,
+                                    &loxFlow,
+                                    &gn2Vent,
+                                    &lngVent,
+                                    &loxVent};
+
+    for (DebouncedInput *item : valve_list)
+    {
+      debounceSwitchRead(item);
+    }
+  }
+}
+
+/**
+ * @brief  Check for safety before entering launch mode
+ *
+ * Only when all valves are claosed, and all switches/buttons are at the
+ * default state, allows to enter into launch mode
+ *
+ * @return true: allow to enter; false; not allowed, check swithch/button states
+ */
+bool launch_mode_check()
+{
+
+  uint8_t curr_rocketState = PRE_ARM;
+
+  for (DebouncedInput *item : valve_list)
+  {
+    debounceSwitchRead(item);
+
+    if (item->currState)
+    {
+      curr_rocketState = openValve(rocketState, item->mask);
+    }
+    else
+    {
+      curr_rocketState = closeValve(rocketState, item->mask);
+    }
+  }
+
+  // Some valves are still opened, closed them before entering into launch mode
+  if (curr_rocketState != PRE_ARM){
+    return false;
+  }
+
+  unsigned int arm_switch = arm.currState;
+  unsigned int abort_button = abort_mission.currState;
+  unsigned int launch_button = launch.currState;
+
+  // One of the launch mode buttons were opened, close them before entering
+  // into launch mode
+  if (arm_switch | abort_button | launch_button){
+    return false;
+  }
+
+  //Force the state to reset to PRE_ARM
+  rocketState = PRE_ARM;
+
+  // Safety entering into launch mode
+  return true;
+}
+
+// ============================================================================
 //                            Mode‑Specific Logic
 // ============================================================================
 /**
@@ -734,33 +828,50 @@ void loop()
   {
   case LAUNCH_MODE:
     // Serial.println("Launch Mode; State = " + String(rocketState, BIN));
-    launch_mode_logic();
 
-    if (operationMode != pre_operationMode){
+    // if the operation mode has changed, force state reset and LCD update
+    if (operationMode != pre_operationMode)
+    {
+      reset_readings();
+
+      // If the safety check fails, force go back to the previous mode
+      if (!launch_mode_check){
+        operationMode = pre_operationMode;
+        break;
+      }
+
       LCD_LaunchMode();
     }
+
+    launch_mode_logic();
 
     break;
 
   case FUELING_MODE:
     // Serial.println("Fueling Mode; State = " + String(rocketState, BIN));
-    fueling_mode_logic();
 
+    // if the operation mode has changed, force state reset and LCD update
     if (operationMode != pre_operationMode)
     {
+      reset_readings();
       LCD_DevAndFueling(1);
     }
+
+    fueling_mode_logic();
 
     break;
 
   case DEV_MODE:
     // Serial.println("Dev Mode; State = " + String(rocketState, BIN));
-    dev_mode_logic();
 
+    // if the operation mode has changed, force state reset and LCD update
     if (operationMode != pre_operationMode)
     {
+      reset_readings();
       LCD_DevAndFueling(0);
     }
+
+    dev_mode_logic();
 
     break;
 

--- a/gs/gs.ino
+++ b/gs/gs.ino
@@ -404,14 +404,40 @@ void reset_readings()
   }
 }
 
-void launch_mode_fail_message()
+/**
+ * @brief  Give out launch mode fail message depending on the event
+ *
+ * @return void
+ */
+void launch_mode_fail_message(uint8_t event_id)
 {
-  lcd.clear(); // wipe previous frame
-  lcd.setCursor(0, 0);
-  lcd.print(" LAUNCH MODE FAILED");
-  lcd.setCursor(0, 1);
-  lcd.print(" CLOSE ALL VALVES  ");
-  delay(1500);
+
+  switch (event_id){
+
+
+    case (0):
+      lcd.clear(); // wipe previous frame
+      lcd.setCursor(0, 0);
+      lcd.print(" LAUNCH MODE FAILED");
+      lcd.setCursor(0, 1);
+      lcd.print(" CLOSE ALL VALVES  ");
+      delay(1500);
+      break;
+
+    case (1):
+        lcd.clear(); // wipe previous frame
+        lcd.setCursor(0, 0);
+        lcd.print(" LAUNCH MODE FAILED");
+        lcd.setCursor(0, 1);
+        String errorMsg = "";
+        errorMsg = "ARM:" + String(arm.currState) +
+                   ", ABT:" + String(abort_mission.currState) +
+                   ", LAU:" + String(launch.currState);
+
+        lcd.print(errorMsg);
+        delay(1500);
+        break;
+  }
 }
 
 /**
@@ -448,9 +474,13 @@ bool launch_mode_check()
   // Some valves are still opened, closed them before entering into launch mode
   if (valve_open_count != 0)
   {
-    launch_mode_fail_message();
+    launch_mode_fail_message(0);
     return false;
   }
+
+  debounceSwitchRead(&arm);
+  debounceAbortRead(&abort_mission);
+  debounceButtonRead(&launch);
 
   unsigned int arm_switch = arm.currState;
   unsigned int abort_button = abort_mission.currState;
@@ -459,7 +489,7 @@ bool launch_mode_check()
   // One of the launch mode buttons were opened, close them before entering
   // into launch mode
   if (arm_switch || abort_button || launch_button){
-    launch_mode_fail_message();
+    launch_mode_fail_message(1);
     return false;
   }
 
@@ -841,66 +871,69 @@ void loop()
 
   operationMode = getModePress(operationMode); // Mode select
 
-  switch (operationMode)
+  if (operationMode != pre_operationMode)
   {
-  case LAUNCH_MODE:
-    // Serial.println("Launch Mode; State = " + String(rocketState, BIN));
+    reset_readings();
+  }
 
-    // if the operation mode has changed, force state reset and LCD update
-    if (operationMode != pre_operationMode)
+  switch (operationMode)
     {
-      reset_readings();
+    case LAUNCH_MODE:
+      // Serial.println("Launch Mode; State = " + String(rocketState, BIN));
 
-      // If the safety check fails, force go back to the previous mode
-      if (!launch_mode_check()){
-        operationMode = pre_operationMode;
-        break;
+      // if the operation mode has changed, force state reset and LCD update
+      if (operationMode != pre_operationMode)
+      {
+        // If the safety check fails, force go back to the previous mode
+        if (!launch_mode_check())
+        {
+          operationMode = pre_operationMode;
+          break;
+        }
+
+        LCD_LaunchMode(); 
       }
 
-      LCD_LaunchMode();
+      launch_mode_logic();
+
+      break;
+
+    case FUELING_MODE:
+      // Serial.println("Fueling Mode; State = " + String(rocketState, BIN));
+
+      // if the operation mode has changed, force state reset and LCD update
+      if (operationMode != pre_operationMode)
+      {
+        LCD_DevAndFueling(1);
+      }
+
+      fueling_mode_logic();
+
+      break;
+
+    case DEV_MODE:
+      // Serial.println("Dev Mode; State = " + String(rocketState, BIN));
+
+      // if the operation mode has changed, force state reset and LCD update
+      if (operationMode != pre_operationMode)
+      {
+        LCD_DevAndFueling(0);
+      }
+
+      dev_mode_logic();
+
+      break;
+
+    default:
+      // Serial.println("Idling Mode");
+      break;
     }
 
-    launch_mode_logic();
-
-    break;
-
-  case FUELING_MODE:
-    // Serial.println("Fueling Mode; State = " + String(rocketState, BIN));
-
-    // if the operation mode has changed, force state reset and LCD update
-    if (operationMode != pre_operationMode)
+    if (millis() - lastSend >= 200)
     {
-      reset_readings();
-      LCD_DevAndFueling(1);
+      lastSend = millis();
+      sendRocketState(rocketState);
     }
 
-    fueling_mode_logic();
-
-    break;
-
-  case DEV_MODE:
-    // Serial.println("Dev Mode; State = " + String(rocketState, BIN));
-
-    // if the operation mode has changed, force state reset and LCD update
-    if (operationMode != pre_operationMode)
-    {
-      reset_readings();
-      LCD_DevAndFueling(0);
-    }
-
-    dev_mode_logic();
-
-    break;
-
-  default:
-    // Serial.println("Idling Mode");
-    break;
+    pre_operationMode = operationMode;
   }
-
-  if(millis()-lastSend >= 200){
-    lastSend = millis();
-    sendRocketState(rocketState);
-  }
-
-  pre_operationMode = operationMode;
-}

--- a/gs/gs.ino
+++ b/gs/gs.ino
@@ -65,8 +65,6 @@ MODE operationMode = NONE_MODE;
 //                           Ethernet (MAC‑RAW) Setup
 // ─────────────────────────────────────────────────────────────────────────────
 // Change this based on which board is used as flight computer.
-#define MAC_SENSOR_DATA MAC_SENSOR_GIGA
-#define MAC_FLOW_CONTROLLER MAC_SENSOR_GIGA
 
 byte pkt[] = {
     0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, // destination
@@ -636,7 +634,7 @@ void sendRocketState(uint8_t currRocketState)
   }
 
   // --- 2) Flow-valve Arduino ---------------------------------------------
-  memcpy(pkt, MAC_SENSOR_GIGA, 6); // destination
+  memcpy(pkt, MAC_FLOW_VALVE, 6); // destination
   // source MAC is already correct, no need to write again
   if (w5500.sendFrame(pkt, sizeof(pkt)) < 0)
   {
@@ -704,42 +702,42 @@ void receiveSensorData()
     memcpy(csv, buffer + 14, payloadLen);
     csv[payloadLen] = '\0';
 
-    /* 3) Split the CSV into 12 floats */
-    float pt[7], lc[3], tc[2];
+    /* 3) Split the CSV into separate floats */
+    float pt[NUM_PTS], lc[NUM_LCS], tc[NUM_TCS];
     char *tok = strtok(csv, ",");
     uint8_t idx = 0;
-    while (tok && idx < 12) {
+    while (tok && idx < NUM_PTS+NUM_LCS+NUM_TCS) {
       float v = atof(tok);
-      if (idx < 7)
+      if (idx < NUM_PTS)
         pt[idx] = v;
-      else if (idx < 10)
-        lc[idx - 7] = v;
+      else if (idx < NUM_PTS + NUM_LCS)
+        lc[idx - NUM_PTS] = v;
       else
-        tc[idx - 10] = v;
+        tc[idx - (NUM_PTS + NUM_LCS)] = v;
       tok = strtok(nullptr, ",");
       ++idx;
     }
-    if (idx != 12)
+    if (idx != NUM_PTS+NUM_LCS+NUM_TCS)
       return; // malformed – drop
 
     /* 4) Stream-print JSON ------------------------------------------------ */
     /* ---- stream out JSON (no inner newlines) ---- */
     Serial.print(F("{\"value\":{\"pt\":["));
-    for (uint8_t i = 0; i < 7; ++i) {
+    for (uint8_t i = 0; i < NUM_PTS; ++i) {
       Serial.print(pt[i], 3);
-      if (i < 6)
+      if (i < NUM_PTS-1)
         Serial.print(',');
     }
     Serial.print(F("],\"tc\":["));
-    for (uint8_t i = 0; i < 2; ++i) {
+    for (uint8_t i = 0; i < NUM_TCS; ++i) {
       Serial.print(tc[i], 3);
-      if (i < 1)
+      if (i < NUM_TCS-1)
         Serial.print(',');
     }
     Serial.print(F("],\"lc\":["));
-    for (uint8_t i = 0; i < 3; ++i) {
+    for (uint8_t i = 0; i < NUM_LCS; ++i) {
       Serial.print(lc[i], 3);
-      if (i < 2)
+      if (i < NUM_LCS-1)
         Serial.print(',');
     }
     Serial.print(F("],\"fcv\":[],\"timestamp\":\""));

--- a/gs/gs.ino
+++ b/gs/gs.ino
@@ -382,7 +382,7 @@ void reset_readings()
   lcd.print("      WAIT...      ");
 
   // Force the ground station to update the switch readings for 2 seconds
-  timer = millis();
+  timer = millis(); 
   while (millis() - timer < 2000){
     // Read all swiches and buttons
     debounceSwitchRead(&arm);
@@ -404,10 +404,20 @@ void reset_readings()
   }
 }
 
+void launch_mode_fail_message()
+{
+  lcd.clear(); // wipe previous frame
+  lcd.setCursor(0, 0);
+  lcd.print(" LAUNCH MODE FAILED");
+  lcd.setCursor(0, 1);
+  lcd.print(" CLOSE ALL VALVES  ");
+  delay(1500);
+}
+
 /**
  * @brief  Check for safety before entering launch mode
  *
- * Only when all valves are claosed, and all switches/buttons are at the
+ * Only when all valves are closed, and all switches/buttons are at the
  * default state, allows to enter into launch mode
  *
  * @return true: allow to enter; false; not allowed, check swithch/button states
@@ -415,7 +425,15 @@ void reset_readings()
 bool launch_mode_check()
 {
 
-  uint8_t curr_rocketState = PRE_ARM;
+  DebouncedInput *valve_list[] = {&lngPressure,
+                                  &loxPressure,
+                                  &lngFlow,
+                                  &loxFlow,
+                                  &gn2Vent,
+                                  &lngVent,
+                                  &loxVent};
+
+  uint8_t valve_open_count = 0;
 
   for (DebouncedInput *item : valve_list)
   {
@@ -423,16 +441,14 @@ bool launch_mode_check()
 
     if (item->currState)
     {
-      curr_rocketState = openValve(rocketState, item->mask);
-    }
-    else
-    {
-      curr_rocketState = closeValve(rocketState, item->mask);
+      valve_open_count++;
     }
   }
 
   // Some valves are still opened, closed them before entering into launch mode
-  if (curr_rocketState != PRE_ARM){
+  if (valve_open_count != 0)
+  {
+    launch_mode_fail_message();
     return false;
   }
 
@@ -442,7 +458,8 @@ bool launch_mode_check()
 
   // One of the launch mode buttons were opened, close them before entering
   // into launch mode
-  if (arm_switch | abort_button | launch_button){
+  if (arm_switch || abort_button || launch_button){
+    launch_mode_fail_message();
     return false;
   }
 
@@ -835,7 +852,7 @@ void loop()
       reset_readings();
 
       // If the safety check fails, force go back to the previous mode
-      if (!launch_mode_check){
+      if (!launch_mode_check()){
         operationMode = pre_operationMode;
         break;
       }


### PR DESCRIPTION
* A switch latch bug was discovered during the static fire
* Trigger condition: Launch Mode -> ARM Switch ON-> Launch Button -> DEV Mode -> ARM Swtich OFF -> Launch Button
* When performing a launch (usually cold flow before static fire), and close the ARM switch outside of the launch mode, there will be a very brief moment that the ground station will sent ARM ON state to the flight computer when entering the launch mode again. This is due to the debounce switch reading mechanism.
* This branch has been archieved in ``static-fire-Feb2026-record``
* The current main branch has patched this fix to enforce a 2 second sensor read stabalization time when swtiching state, as well as a state check when entering the launch mode. Any invalid state will prevent entering the launch mode and revert back to the previous state.